### PR TITLE
feat: add self-hosted forges support

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -102,7 +102,8 @@ as an `Authorization` header to that forge's API.
 
 The options page is forge-agnostic: it renders one token field per forge that
 declares authentication support (see `authForges()` in `forges.js`), so a new
-authenticated forge needs no options-page change.
+authenticated forge needs no options-page change. Self-hosted instances (see
+[Forges](#forges)) get their own token field too, keyed per instance.
 
 For GitHub, create a [personal access token][gh-token] (classic or
 fine-grained) — no scope is required for public repositories; grant repository
@@ -121,15 +122,18 @@ in your account settings with repository read scope. For GitLab, create a
 
 Forge endpoints are configured in `forges.js`, which defines one **adapter**
 per forge that normalizes its API and URL quirks behind a common interface,
-plus a `forgeForHostname()` registry lookup.
+plus a `forgeForHostname()` registry lookup. Single-host forges (GitHub,
+Bitbucket) are plain adapter objects; multi-host forges (GitLab, Forgejo/Gitea)
+are *families* whose instances — public and self-hosted alike — are built with
+`instanceOf()` (see [Families and self-hosted forges](#families-and-self-hosted-forges)).
 
 Here is the interface for each forge:
 
 | Member       | Purpose                                                            |
 | ------------ | ------------------------------------------------------------------ |
 | `label`      | human-readable forge name                                          |
-| `hostnames`  | array of hostnames (static forges only)                            |
-| `base_url`   | API URL (static forges only)                                       |
+| `hostnames`  | array of hostnames matched against the page (one per family instance) |
+| `base_url`   | API root URL the endpoint builders are hung off of                |
 | `parseUrl`   | `(URL) → { projectKey, repoSlug, filepath, origin }` or `null`     |
 | `listPRsUrl` | API endpoint listing the repo's open PRs                           |
 | `pullRequests` | `(listResponse) → array of PR objects` (unwraps paginated envelopes) |
@@ -156,6 +160,32 @@ Supported forges:
 - **Bitbucket** (Cloud): https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/
 - **Codeberg** (Forgejo, Gitea-compatible API): https://forgejo.org/docs/latest/user/api-usage/
 - **GitLab**: https://docs.gitlab.com/ee/api/merge_requests.html.
+
+### Families and self-hosted forges
+
+A forge's API and URL layout are the same across every host running the same
+software, so `forges.js` factors that shared logic into a *family* and builds
+concrete adapters from it with `instanceOf(family, { hostname, … })`. Both the
+built-in public forges and the user's self-hosted forges are built this way, so
+a self-hosted forge is just an `instanceOf` created at runtime by
+`buildSelfHostedForge()` from an instance the user configured.
+
+Users add instances (a hostname and which software family it runs) on the
+options page; they are stored under `selfHostedInstances` in
+`browser.storage.local`, and `forgeForHostname()` matches a page against the
+built-in forges first, then those instances.
+
+Because Manifest V3 cannot declare arbitrary hosts up front, the options page
+**requests the host permission** for an instance when it is added and releases
+it on removal (both need `optional_host_permissions`); the background script
+skips an instance until its permission is granted.
+
+Supported self-hosted software:
+- **GitLab** (CE/EE): https://docs.gitlab.com/ee/api/merge_requests.html
+- **Forgejo / Gitea**: https://forgejo.org/docs/latest/user/api-usage/
+
+To support new self-hosted software, define its family and add it to
+`selfHostedFamilies`.
 
 ## Internationalization
 

--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ API rate limit and list pull requests from private repositories.
 - Bitbucket
 - Codeberg
 - GitLab
+- self-hosted GitLab (CE/EE) and Forgejo/Gitea instances (add them in the
+  extension's options)

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -46,5 +46,45 @@
   "optionsCleared": {
     "message": "Token cleared",
     "description": "Status message shown after clearing the token"
+  },
+  "optionsSelfHostedTitle": {
+    "message": "Self-hosted forges",
+    "description": "Title of the self-hosted forges section on the options page"
+  },
+  "optionsSelfHostedHint": {
+    "message": "Add your own self-hosted forge instance. Adding one asks for permission to access that site.",
+    "description": "Hint explaining the self-hosted forges section"
+  },
+  "optionsAddInstance": {
+    "message": "Add",
+    "description": "Label of the button that adds a self-hosted instance"
+  },
+  "optionsHostnamePlaceholder": {
+    "message": "git.example.com",
+    "description": "Placeholder for the self-hosted instance hostname input"
+  },
+  "optionsRemove": {
+    "message": "Remove",
+    "description": "Label of the button that removes a self-hosted instance"
+  },
+  "optionsInvalidHostname": {
+    "message": "Enter a valid hostname",
+    "description": "Status message when the entered instance hostname is invalid"
+  },
+  "optionsInstanceExists": {
+    "message": "This instance is already configured",
+    "description": "Status message when adding an instance that already exists"
+  },
+  "optionsInstanceAdded": {
+    "message": "Instance added",
+    "description": "Status message shown after adding a self-hosted instance"
+  },
+  "optionsInstanceRemoved": {
+    "message": "Instance removed",
+    "description": "Status message shown after removing a self-hosted instance"
+  },
+  "optionsPermissionDenied": {
+    "message": "Permission to access this instance was denied",
+    "description": "Status message when the host permission request is denied"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -46,5 +46,45 @@
   "optionsCleared": {
     "message": "Jeton effacé",
     "description": "Message affiché après l'effacement du jeton"
+  },
+  "optionsSelfHostedTitle": {
+    "message": "Forges auto-hébergées",
+    "description": "Titre de la section des forges auto-hébergées sur la page d'options"
+  },
+  "optionsSelfHostedHint": {
+    "message": "Ajoutez votre propre instance de forge auto-hébergée. L'ajout demande l'autorisation d'accéder à ce site.",
+    "description": "Aide expliquant la section des forges auto-hébergées"
+  },
+  "optionsAddInstance": {
+    "message": "Ajouter",
+    "description": "Libellé du bouton d'ajout d'une instance auto-hébergée"
+  },
+  "optionsHostnamePlaceholder": {
+    "message": "git.exemple.com",
+    "description": "Texte indicatif du champ de nom d'hôte de l'instance auto-hébergée"
+  },
+  "optionsRemove": {
+    "message": "Supprimer",
+    "description": "Libellé du bouton de suppression d'une instance auto-hébergée"
+  },
+  "optionsInvalidHostname": {
+    "message": "Saisissez un nom d'hôte valide",
+    "description": "Message affiché quand le nom d'hôte saisi est invalide"
+  },
+  "optionsInstanceExists": {
+    "message": "Cette instance est déjà configurée",
+    "description": "Message affiché lors de l'ajout d'une instance déjà présente"
+  },
+  "optionsInstanceAdded": {
+    "message": "Instance ajoutée",
+    "description": "Message affiché après l'ajout d'une instance auto-hébergée"
+  },
+  "optionsInstanceRemoved": {
+    "message": "Instance supprimée",
+    "description": "Message affiché après la suppression d'une instance auto-hébergée"
+  },
+  "optionsPermissionDenied": {
+    "message": "L'autorisation d'accéder à cette instance a été refusée",
+    "description": "Message affiché quand la demande d'autorisation d'hôte est refusée"
   }
 }

--- a/_locales/template.json
+++ b/_locales/template.json
@@ -46,5 +46,45 @@
   "optionsCleared": {
     "message": "",
     "description": ""
+  },
+  "optionsSelfHostedTitle": {
+    "message": "",
+    "description": ""
+  },
+  "optionsSelfHostedHint": {
+    "message": "",
+    "description": ""
+  },
+  "optionsAddInstance": {
+    "message": "",
+    "description": ""
+  },
+  "optionsHostnamePlaceholder": {
+    "message": "",
+    "description": ""
+  },
+  "optionsRemove": {
+    "message": "",
+    "description": ""
+  },
+  "optionsInvalidHostname": {
+    "message": "",
+    "description": ""
+  },
+  "optionsInstanceExists": {
+    "message": "",
+    "description": ""
+  },
+  "optionsInstanceAdded": {
+    "message": "",
+    "description": ""
+  },
+  "optionsInstanceRemoved": {
+    "message": "",
+    "description": ""
+  },
+  "optionsPermissionDenied": {
+    "message": "",
+    "description": ""
   }
 }

--- a/background.js
+++ b/background.js
@@ -163,15 +163,32 @@ function render(prs, tabId) {
     browser.storage.local.set({ tabId, prs })
 }
 
+// load the user's configured self-hosted instances from storage
+// returns an array of { type, hostname } (empty when none configured)
+async function loadInstances() {
+    const stored = await browser.storage.local.get("selfHostedInstances")
+    return stored.selfHostedInstances || []
+}
+
 async function main(tab) {
     // split the url
     const url = new URL(tab.url)
 
-    // get the forge adapter by hostname
-    const forge = forgeForHostname(url.hostname)
+    // get the forge adapter by hostname, considering configured self-hosted
+    // instances alongside the built-in forges
+    const instances = await loadInstances()
+    const forge = forgeForHostname(url.hostname, instances)
     if (forge == null) {
         return
     }
+
+    // self-hosted instances need an optional host permission before the
+    // extension may call their API; skip quietly until the user grants it
+    if (forge.selfHosted &&
+        !(await browser.permissions.contains({ origins: [`*://${url.hostname}/*`] }))) {
+        return
+    }
+
     browser.action.enable(tab.id)
 
     // get project info from the URL (forge-specific parsing)

--- a/forges.js
+++ b/forges.js
@@ -1,13 +1,16 @@
 // Each forge is an adapter that normalizes its API + URL quirks behind a common
-// interface used by background.js and popup.js. Adding a new forge is a new
-// adapter object here (plus a host permission); background.js / popup.js stay
-// unchanged.
+// interface used by background.js and popup.js. A single-host forge is a plain
+// adapter object here; a forge whose software can run on many hosts is
+// expressed as a *family* holding the shared logic, from which the public
+// instance and any self-hosted instances are built with instanceOf() (see
+// below). Adding a forge (plus a host permission) leaves background.js /
+// popup.js unchanged.
 //
 // Adapter interface:
 //   label       human-readable forge name, shown in the options page UI
-//   hostnames   array of substrings matched against the page hostname (static
-//               forges only; self-hosted forges are matched against the user's
-//               configured instance list instead)
+//   hostnames   array of substrings matched against the page hostname (for a
+//               family instance this is its single configured hostname)
+//   base_url    API root URL the endpoint builders below are hung off of
 //   parseUrl    (URL) -> { projectKey, repoSlug, filepath, origin } | null
 //   listPRsUrl  (info) -> API endpoint listing the repo's open pull requests
 //   pullRequests (listResponse) -> array of PR objects from the list response
@@ -130,13 +133,32 @@ export const bitbucket = {
     },
 }
 
-// Codeberg is a public instance of Forgejo (a Gitea fork), so it speaks the
-// Gitea-compatible REST API served at https://codeberg.org/api/v1.
+// Forge software can run on many hosts (a public instance plus any number of
+// self-hosted ones), all speaking the same API with the same URL layout. That
+// shared behaviour lives in a forge *family*; a concrete adapter is an
+// *instance* of a family, differing only by hostname, API base URL and token
+// key. instanceOf() specialises a family into an adapter — used both for the
+// built-in public instances below and for the user's self-hosted instances (see
+// buildSelfHostedForge). A family therefore owns every interface member except
+// `label`, `hostnames`, `base_url` and `tokenStorageKey`, which the instance
+// supplies.
+//
+// `apiPath` is the family's API root; appended to the instance origin it forms
+// base_url, so the public and self-hosted instances share one code path.
+function instanceOf(family, { hostname, label, tokenStorageKey }) {
+    return Object.assign(Object.create(family), {
+        label: label ?? hostname,
+        hostnames: [hostname],
+        base_url: `https://${hostname}${family.apiPath}`,
+        tokenStorageKey,
+    })
+}
+
+// Forgejo / Gitea family: speaks the Gitea-compatible REST API under /api/v1.
 // API docs: https://forgejo.org/docs/latest/user/api-usage/
-export const codeberg = {
-    label: "Codeberg",
-    hostnames: ["codeberg.org"],
-    base_url: "https://codeberg.org/api/v1",
+const forgejoFamily = {
+    label: "Forgejo / Gitea",
+    apiPath: "/api/v1",
 
     parseUrl(url) {
         // file view: /{owner}/{repo}/src/{branch|commit|tag}/{ref}/{filepath}
@@ -171,27 +193,31 @@ export const codeberg = {
         return `${info.origin}/${info.projectKey}/${info.repoSlug}/pulls/${prNumber}`
     },
 
-    // Codeberg exposes no simple rate-limit endpoint.
+    // Forgejo/Gitea exposes no simple rate-limit endpoint.
     rateLimit: null,
 
-    // Codeberg accepts a personal access token via the Gitea `token` scheme.
-    tokenStorageKey: "codebergToken",
-
+    // Forgejo/Gitea accepts a personal access token via the `token` scheme.
     authHeader(token) {
         return { Authorization: `token ${token}` }
     },
 }
 
+// Codeberg is the public Forgejo instance.
+export const codeberg = instanceOf(forgejoFamily, {
+    hostname: "codeberg.org",
+    label: "Codeberg",
+    tokenStorageKey: "codebergToken",
+})
+
+// GitLab family: calls PRs "merge requests" and identifies a project by its
+// full, URL-encoded path (namespaces can be nested: group/subgroup/project), so
+// `info` carries a single `projectPath` rather than a projectKey / repoSlug
+// pair. The `/-/` separator in web URLs delimits the project path from the
+// route type (blob, merge_requests, …).
 // API docs: https://docs.gitlab.com/ee/api/merge_requests.html
-// GitLab calls PRs "merge requests" and identifies a project by its full,
-// URL-encoded path (namespaces can be nested: group/subgroup/project), so the
-// adapter carries a single `projectPath` in `info` rather than a projectKey /
-// repoSlug pair. The `/-/` separator in web URLs delimits the project path from
-// the route type (blob, merge_requests, …).
-export const gitlab = {
+const gitlabFamily = {
     label: "GitLab",
-    hostnames: ["gitlab.com"],
-    base_url: "https://gitlab.com/api/v4",
+    apiPath: "/api/v4",
 
     parseUrl(url) {
         // file view: /{group}/.../{project}/-/blob/{ref}/{filepath}
@@ -240,23 +266,78 @@ export const gitlab = {
 
     // GitLab accepts a personal or project access token via the PRIVATE-TOKEN
     // header. Authenticating grants access to private repositories.
-    tokenStorageKey: "gitlabToken",
-
     authHeader(token) {
         return { "PRIVATE-TOKEN": token }
     },
 }
 
+// gitlab.com is the public GitLab instance.
+export const gitlab = instanceOf(gitlabFamily, {
+    hostname: "gitlab.com",
+    tokenStorageKey: "gitlabToken",
+})
+
 // registry of forges matched by a static hostname
 const staticForges = [github, bitbucket, codeberg, gitlab]
-
-// pick a forge adapter for a page hostname (null if none matches).
-export function forgeForHostname(hostname) {
-    return staticForges.find(f => f.hostnames.some(h => hostname.includes(h))) || null
-}
 
 // forges that support authentication (declare both a token storage key and a
 // header builder); the options page renders one token field per such forge.
 export function authForges() {
     return staticForges.filter(f => f.tokenStorageKey && f.authHeader)
+}
+
+//
+// Self-hosted forges
+//
+// A self-hosted forge runs the same software as one of the families above, so
+// it is simply another instanceOf() of that family — built at runtime from the
+// hostname the user configured rather than hardcoded. Only forges expressed as
+// a family can be self-hosted; a single-host adapter would need converting to a
+// family first.
+//
+// `type` (stored with the user's instance config) selects the family.
+const selfHostedFamilies = {
+    gitlab: gitlabFamily,
+    forgejo: forgejoFamily,
+}
+
+// software types selectable when adding a self-hosted instance, for the options
+// page dropdown: [{ type, label }, …]
+export function selfHostedTypes() {
+    return Object.entries(selfHostedFamilies).map(([type, family]) => ({
+        type,
+        label: family.label,
+    }))
+}
+
+// storage.local key holding the (optional) token for a self-hosted instance;
+// keyed by hostname so every instance keeps its own token
+export function selfHostedTokenKey(hostname) {
+    return `selfHostedToken:${hostname}`
+}
+
+// build a forge adapter for a configured instance ({ type, hostname }); the
+// same instanceOf() used for the public instances, tagged so the background can
+// tell it needs an optional host permission. Returns null for an unknown type.
+export function buildSelfHostedForge({ type, hostname }) {
+    const family = selfHostedFamilies[type]
+    if (!family) return null
+
+    const forge = instanceOf(family, {
+        hostname,
+        tokenStorageKey: selfHostedTokenKey(hostname),
+    })
+    return Object.assign(forge, { selfHosted: true, type })
+}
+
+// pick a forge adapter for a page hostname, considering both the built-in
+// static forges and the user's configured self-hosted instances (null if none
+// matches). Static forges win; self-hosted instances are matched by exact
+// hostname to avoid one instance shadowing another.
+export function forgeForHostname(hostname, instances = []) {
+    const staticForge = staticForges.find(f => f.hostnames.some(h => hostname.includes(h)))
+    if (staticForge) return staticForge
+
+    const instance = instances.find(i => i.hostname === hostname)
+    return instance ? buildSelfHostedForge(instance) : null
 }

--- a/manifest.json
+++ b/manifest.json
@@ -56,5 +56,8 @@
     "*://api.bitbucket.org/*",
     "*://codeberg.org/*",
     "*://gitlab.com/*"
+  ],
+  "optional_host_permissions": [
+    "*://*/*"
   ]
 }

--- a/options/options.css
+++ b/options/options.css
@@ -22,3 +22,16 @@ body { background: var(--bg); color: var(--fg); }
 }
 .options__actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
 .options__status { color: var(--muted); min-height: 1.2em; }
+
+.options__self-hosted {
+  display: flex; flex-direction: column; gap: 0.5rem;
+  border-top: 1px solid var(--border); padding-top: 0.75rem;
+}
+.options__subtitle { margin: 0; }
+.options__add { display: flex; gap: 0.5rem; align-items: center; }
+.options__add .options__input { flex: 1; }
+.options__remove, .options__add-btn {
+  align-self: flex-start;
+  padding: 0.4rem 0.75rem; border: 1px solid var(--border); border-radius: 4px;
+  background: var(--bg); color: var(--fg); cursor: pointer;
+}

--- a/options/options.html
+++ b/options/options.html
@@ -15,6 +15,24 @@
         <!-- one token field per authenticated forge, rendered by options.js -->
         <div id="forges"></div>
 
+        <!-- self-hosted forge instances -->
+        <section class="options__self-hosted">
+          <h4 class="options__subtitle" i18n=1>__MSG_optionsSelfHostedTitle__</h4>
+          <p class="options__hint" i18n=1>__MSG_optionsSelfHostedHint__</p>
+
+          <!-- one fieldset per configured instance, rendered by options.js -->
+          <div id="instances"></div>
+
+          <div class="options__add">
+            <select id="instance-type" class="options__input"></select>
+            <input id="instance-hostname" class="options__input" type="text"
+                   autocomplete="off" spellcheck="false">
+            <button type="button" id="add-instance" class="options__add-btn"
+                    i18n=1>__MSG_optionsAddInstance__</button>
+          </div>
+          <p id="instance-status" class="options__status" role="status"></p>
+        </section>
+
         <div class="options__actions">
           <button type="submit" class="options__save" i18n=1>__MSG_optionsSave__</button>
           <button type="button" id="clear" class="options__clear" i18n=1>__MSG_optionsClear__</button>

--- a/options/options.js
+++ b/options/options.js
@@ -1,5 +1,5 @@
 import { browser } from "../browser.js"
-import { authForges } from "../forges.js"
+import { authForges, selfHostedTypes, selfHostedTokenKey } from "../forges.js"
 
 //
 // Functions
@@ -23,8 +23,8 @@ function localize() {
     }
 }
 
-function showStatus(messageKey) {
-    document.getElementById("status").textContent = browser.i18n.getMessage(messageKey)
+function showStatus(messageKey, elementId = "status") {
+    document.getElementById(elementId).textContent = browser.i18n.getMessage(messageKey)
 }
 
 // render one token field per authenticated forge; each input is tagged with the
@@ -69,7 +69,7 @@ function renderForges() {
 async function loadTokens() {
     try {
         const stored = await browser.storage.local.get()
-        for (const input of document.querySelectorAll("#forges input")) {
+        for (const input of document.querySelectorAll("input[data-storage-key]")) {
             const value = stored[input.dataset.storageKey]
             if (value) {
                 input.value = value
@@ -86,7 +86,7 @@ async function saveTokens(event) {
 
     const toSet = {}
     const toRemove = []
-    for (const input of document.querySelectorAll("#forges input")) {
+    for (const input of document.querySelectorAll("input[data-storage-key]")) {
         const token = input.value.trim()
         if (token) {
             toSet[input.dataset.storageKey] = token
@@ -109,7 +109,7 @@ async function saveTokens(event) {
 // remove every forge token
 async function clearTokens() {
     const keys = []
-    for (const input of document.querySelectorAll("#forges input")) {
+    for (const input of document.querySelectorAll("input[data-storage-key]")) {
         input.value = ""
         keys.push(input.dataset.storageKey)
     }
@@ -123,10 +123,145 @@ async function clearTokens() {
 }
 
 //
+// Self-hosted instances
+//
+// normalize a user-entered instance address to a bare hostname; accepts a full
+// URL or a bare hostname, returns null when it cannot be parsed
+function normalizeHostname(value) {
+    let raw = value.trim()
+    if (!raw) return null
+    if (!raw.includes("://")) raw = `https://${raw}`
+    try {
+        return new URL(raw).hostname || null
+    } catch {
+        return null
+    }
+}
+
+// populate the software-type dropdown for the "add instance" form
+function renderTypeOptions() {
+    const select = document.getElementById("instance-type")
+    for (const { type, label } of selfHostedTypes()) {
+        const option = document.createElement("option")
+        option.value = type
+        option.textContent = label
+        select.appendChild(option)
+    }
+}
+
+// render one fieldset per configured self-hosted instance: its label, a token
+// field (tagged with the shared data-storage-key so load/save/clear handle it)
+// and a remove button
+async function renderInstances() {
+    const container = document.getElementById("instances")
+    container.replaceChildren()
+
+    const stored = await browser.storage.local.get("selfHostedInstances")
+    const instances = stored.selfHostedInstances || []
+    const typeLabels = Object.fromEntries(selfHostedTypes().map(t => [t.type, t.label]))
+
+    for (const instance of instances) {
+        const fieldset = document.createElement("fieldset")
+        fieldset.className = "options__forge"
+
+        const legend = document.createElement("legend")
+        legend.textContent = `${instance.hostname} — ${typeLabels[instance.type] || instance.type}`
+        fieldset.appendChild(legend)
+
+        const key = selfHostedTokenKey(instance.hostname)
+
+        const label = document.createElement("label")
+        label.className = "options__label"
+        label.setAttribute("for", key)
+        label.textContent = browser.i18n.getMessage("optionsTokenLabel")
+        fieldset.appendChild(label)
+
+        const input = document.createElement("input")
+        input.type = "password"
+        input.id = key
+        input.className = "options__input"
+        input.autocomplete = "off"
+        input.spellcheck = false
+        input.dataset.storageKey = key
+        fieldset.appendChild(input)
+
+        const remove = document.createElement("button")
+        remove.type = "button"
+        remove.className = "options__remove"
+        remove.textContent = browser.i18n.getMessage("optionsRemove")
+        remove.addEventListener("click", () => removeInstance(instance.hostname))
+        fieldset.appendChild(remove)
+
+        container.appendChild(fieldset)
+    }
+}
+
+// add a self-hosted instance: validate the hostname, request the host
+// permission (this click is the required user gesture), then persist it
+async function addInstance() {
+    const type = document.getElementById("instance-type").value
+    const hostname = normalizeHostname(document.getElementById("instance-hostname").value)
+    if (!hostname) {
+        showStatus("optionsInvalidHostname", "instance-status")
+        return
+    }
+
+    try {
+        const stored = await browser.storage.local.get("selfHostedInstances")
+        const instances = stored.selfHostedInstances || []
+
+        if (instances.some(i => i.hostname === hostname)) {
+            showStatus("optionsInstanceExists", "instance-status")
+            return
+        }
+
+        // the extension may only call the instance API once the user grants
+        // access to its origin
+        const granted = await browser.permissions.request({ origins: [`*://${hostname}/*`] })
+        if (!granted) {
+            showStatus("optionsPermissionDenied", "instance-status")
+            return
+        }
+
+        instances.push({ type, hostname })
+        await browser.storage.local.set({ selfHostedInstances: instances })
+        document.getElementById("instance-hostname").value = ""
+        await renderInstances()
+        await loadTokens()
+        showStatus("optionsInstanceAdded", "instance-status")
+    } catch (error) {
+        console.error(`Error: ${error}`)
+    }
+}
+
+// remove a self-hosted instance: drop it from storage, forget its token and
+// give back the host permission we no longer need
+async function removeInstance(hostname) {
+    try {
+        const stored = await browser.storage.local.get("selfHostedInstances")
+        const instances = (stored.selfHostedInstances || []).filter(i => i.hostname !== hostname)
+
+        await browser.storage.local.set({ selfHostedInstances: instances })
+        await browser.storage.local.remove(selfHostedTokenKey(hostname))
+        await browser.permissions.remove({ origins: [`*://${hostname}/*`] })
+
+        await renderInstances()
+        showStatus("optionsInstanceRemoved", "instance-status")
+    } catch (error) {
+        console.error(`Error: ${error}`)
+    }
+}
+
+//
 // Main
 //
 localize()
 renderForges()
-loadTokens()
+renderTypeOptions()
+document.getElementById("instance-hostname").placeholder =
+    browser.i18n.getMessage("optionsHostnamePlaceholder")
+// fill token fields once both the static forges and the instances are rendered
+renderInstances().then(loadTokens)
 document.getElementById("options-form").addEventListener("submit", saveTokens)
 document.getElementById("clear").addEventListener("click", clearTokens)
+document.getElementById("add-instance").addEventListener("click", addInstance)

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -4,12 +4,14 @@ import { forgeForHostname } from "../forges.js"
 //
 // Functions
 //
-function getUrlInfo(tab) {
+async function getUrlInfo(tab) {
     // split the url
     const url = new URL(tab.url)
 
-    // pick the forge adapter and parse the URL through it (null on a non-forge / non-file page)
-    const forge = forgeForHostname(url.hostname)
+    // pick the forge adapter (built-in or a configured self-hosted instance)
+    // and parse the URL through it (null on a non-forge / non-file page)
+    const stored = await browser.storage.local.get("selfHostedInstances")
+    const forge = forgeForHostname(url.hostname, stored.selfHostedInstances || [])
     if (!forge) return null
     const info = forge.parseUrl(url)
     if (!info) return null
@@ -86,7 +88,7 @@ async function init() {
     const tabId = tabInfo.id
 
     // get url info
-    const urlInfo = getUrlInfo(tabInfo)
+    const urlInfo = await getUrlInfo(tabInfo)
     if (!urlInfo) {
         return
     }

--- a/tests/forges.test.js
+++ b/tests/forges.test.js
@@ -1,7 +1,11 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { github, bitbucket, codeberg, gitlab, forgeForHostname } from "../forges.js"
+import {
+    github, bitbucket, codeberg, gitlab,
+    forgeForHostname,
+    selfHostedTypes, selfHostedTokenKey, buildSelfHostedForge,
+} from "../forges.js"
 
 //
 // forgeForHostname
@@ -330,4 +334,78 @@ test("gitlab.authHeader builds a PRIVATE-TOKEN header", () => {
     assert.deepEqual(gitlab.authHeader("gl_secret"), {
         "PRIVATE-TOKEN": "gl_secret",
     })
+})
+
+//
+// self-hosted forges
+//
+test("selfHostedTypes lists the supported software with labels", () => {
+    assert.deepEqual(selfHostedTypes(), [
+        { type: "gitlab", label: "GitLab" },
+        { type: "forgejo", label: "Forgejo / Gitea" },
+    ])
+})
+
+test("selfHostedTokenKey keys the token by hostname", () => {
+    assert.equal(selfHostedTokenKey("git.example.com"), "selfHostedToken:git.example.com")
+})
+
+test("buildSelfHostedForge returns null for an unknown software type", () => {
+    assert.equal(buildSelfHostedForge({ type: "svn", hostname: "git.example.com" }), null)
+})
+
+test("buildSelfHostedForge builds a GitLab instance adapter reusing the gitlab logic", () => {
+    const forge = buildSelfHostedForge({ type: "gitlab", hostname: "gitlab.example.com" })
+
+    assert.equal(forge.label, "gitlab.example.com")
+    assert.deepEqual(forge.hostnames, ["gitlab.example.com"])
+    assert.equal(forge.base_url, "https://gitlab.example.com/api/v4")
+    assert.equal(forge.tokenStorageKey, "selfHostedToken:gitlab.example.com")
+    assert.equal(forge.selfHosted, true)
+
+    // API/URL builders reuse the gitlab implementation against the instance
+    const info = { projectPath: "group/widget", origin: "https://gitlab.example.com" }
+    assert.equal(
+        forge.listPRsUrl(info),
+        "https://gitlab.example.com/api/v4/projects/group%2Fwidget/merge_requests?state=opened")
+    assert.equal(forge.prNumber({ iid: 7 }), 7)
+    assert.deepEqual(forge.authHeader("gl_secret"), { "PRIVATE-TOKEN": "gl_secret" })
+})
+
+test("buildSelfHostedForge builds a Forgejo instance adapter reusing the codeberg logic", () => {
+    const forge = buildSelfHostedForge({ type: "forgejo", hostname: "git.example.com" })
+
+    assert.equal(forge.base_url, "https://git.example.com/api/v1")
+    const info = { projectKey: "acme", repoSlug: "widget" }
+    assert.equal(
+        forge.filesUrl(info, { number: 42 }),
+        "https://git.example.com/api/v1/repos/acme/widget/pulls/42/files")
+    assert.deepEqual(forge.authHeader("cb_secret"), { Authorization: "token cb_secret" })
+})
+
+test("the public instance and a self-hosted instance share one family", () => {
+    // the inversion: gitlab.com is itself an instanceOf the GitLab family, the
+    // same family a self-hosted GitLab is built from, so they share a prototype
+    const selfHosted = buildSelfHostedForge({ type: "gitlab", hostname: "gitlab.example.com" })
+    assert.equal(Object.getPrototypeOf(gitlab), Object.getPrototypeOf(selfHosted))
+
+    const selfHostedForgejo = buildSelfHostedForge({ type: "forgejo", hostname: "git.example.com" })
+    assert.equal(Object.getPrototypeOf(codeberg), Object.getPrototypeOf(selfHostedForgejo))
+})
+
+test("forgeForHostname matches a configured self-hosted instance", () => {
+    const instances = [{ type: "gitlab", hostname: "gitlab.example.com" }]
+    const forge = forgeForHostname("gitlab.example.com", instances)
+    assert.equal(forge.base_url, "https://gitlab.example.com/api/v4")
+    assert.equal(forge.selfHosted, true)
+})
+
+test("forgeForHostname prefers a static forge over instances", () => {
+    const instances = [{ type: "gitlab", hostname: "github.com" }]
+    assert.equal(forgeForHostname("github.com", instances), github)
+})
+
+test("forgeForHostname matches a self-hosted instance by exact hostname only", () => {
+    const instances = [{ type: "forgejo", hostname: "git.example.com" }]
+    assert.equal(forgeForHostname("other.example.com", instances), null)
 })


### PR DESCRIPTION
A self-hosted forge is described as a "family" adapter, holding the forge logic, then built with the `instanceOf` function. Public instances are new instances of a family: Codeberg for Forgejo, GitLab for GitLab (CE/EE).
About configuration for self-hosted instances:
- the configuration is described into the options page
- host permissions are optional and requested via the options page when an instance is added.

Forgejo and GitLab CE/EE are the two self-hosted forges covered as adapters already exists.

Ref #1
Ref #9
Ref #10