### PR TITLE
refactor: extract duplicated localize function

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -59,6 +59,7 @@ On open, the popup:
 ├── manifest.json          # MV3 manifest
 ├── background.js          # service worker: fetch PRs, match file, set badge
 ├── browser.js             # cross-browser WebExtension API shim (browser/chrome)
+├── i18n.js                # shared localize() for the popup and options pages
 ├── forges.js              # per-forge API endpoint config
 ├── popup/
 │   ├── popup.html         # popup markup
@@ -196,7 +197,8 @@ Translations live in `_locales/<lang>/messages.json`. The default locale is
 language if it exists.
 
 Strings are resolved two ways:
-- `__MSG_<key>__` placeholders
+- `__MSG_<key>__` placeholders in page markup, swapped in at load time by the
+  shared `localize()` in `i18n.js` (used by both the popup and options pages)
 - `browser.i18n.getMessage("<key>")` (in `popup.js` and `options.js`).
 
 To add a locale:

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,19 @@
+import { browser } from "./browser.js"
+
+// Replace every __MSG_<key>__ placeholder in the text of the page's
+// [i18n]-tagged elements with its localized string. Shared by the popup and the
+// options page; `root` defaults to the document but can be a subtree (or a mock
+// in tests).
+export function localize(root = document) {
+    for (const element of root.querySelectorAll("[i18n]")) {
+        const text = element.textContent
+        const localized = text.replace(
+            /__MSG_(\w+)__/g,
+            (match, key) => (key ? browser.i18n.getMessage(key) : ""),
+        )
+
+        if (localized !== text) {
+            element.textContent = localized
+        }
+    }
+}

--- a/options/options.js
+++ b/options/options.js
@@ -1,28 +1,10 @@
 import { browser } from "../browser.js"
 import { authForges, selfHostedTypes, selfHostedTokenKey } from "../forges.js"
+import { localize } from "../i18n.js"
 
 //
 // Functions
 //
-function localize() {
-    // Localize by replacing __MSG_***__ meta tags
-    const toLocalize = document.querySelectorAll("[i18n]")
-    for (let i = 0; i < toLocalize.length; i++) {
-        const obj = toLocalize[i]
-        const text = obj.textContent
-        const textLocalized = text.replace(
-            /__MSG_(\w+)__/g,
-            function(match, v1) {
-                return v1 ? browser.i18n.getMessage(v1) : ""
-            }
-        )
-
-        if (textLocalized != text) {
-            obj.textContent = textLocalized
-        }
-    }
-}
-
 function showStatus(messageKey, elementId = "status") {
     document.getElementById(elementId).textContent = browser.i18n.getMessage(messageKey)
 }

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,5 +1,6 @@
 import { browser } from "../browser.js"
 import { forgeForHostname } from "../forges.js"
+import { localize } from "../i18n.js"
 
 //
 // Functions
@@ -56,25 +57,6 @@ export function renderError(urlInfo) {
     const ul = document.getElementById("prs")
     document.body.replaceChild(div, ul)
 
-}
-
-function localize() {
-    //Localize by replacing __MSG_***__ meta tags
-    var toLocalize = document.querySelectorAll("[i18n]")
-    for (var i=0; i < toLocalize.length; i++) {
-        var obj = toLocalize[i]
-        var text = obj.textContent
-        var textLocalized = text.replace(
-            /__MSG_(\w+)__/g,
-            function(match, v1) {
-                return v1 ? browser.i18n.getMessage(v1) : ""
-            }
-        )
-
-        if(textLocalized != text) {
-            obj.textContent = textLocalized
-        }
-    }
 }
 
 //

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -1,0 +1,47 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+// localize() reads the browser.i18n namespace through the browser shim, which
+// resolves from globalThis at import time; install a mock before importing.
+//
+// Contract: the mock MUST be installed before the dynamic import() below —
+// keep it dynamic, do not turn it into a static import (those are hoisted and
+// would run before the mock is set). The mock is left on globalThis without
+// teardown; that is safe because `node --test` runs each test file in its own
+// process, so it cannot leak into other test files. Both assumptions break
+// under an in-process runner (e.g. --test-isolation=none).
+globalThis.browser = {
+    i18n: { getMessage: (key) => (key === "greeting" ? "Hello" : `<${key}>`) },
+}
+const { localize } = await import("../i18n.js")
+
+// a minimal element stand-in exposing just textContent
+function element(textContent) {
+    return { textContent }
+}
+
+// a fake root whose querySelectorAll("[i18n]") returns the given elements
+function root(elements) {
+    return { querySelectorAll: () => elements }
+}
+
+test("localize replaces a __MSG_<key>__ placeholder with its translation", () => {
+    const el = element("__MSG_greeting__")
+    localize(root([el]))
+    assert.equal(el.textContent, "Hello")
+})
+
+test("localize replaces every placeholder across the tagged elements", () => {
+    const a = element("__MSG_greeting__")
+    const b = element("prefix __MSG_missing__ suffix")
+    localize(root([a, b]))
+    assert.equal(a.textContent, "Hello")
+    assert.equal(b.textContent, "prefix <missing> suffix")
+})
+
+test("localize leaves text without a placeholder untouched", () => {
+    const el = element("plain text")
+    localize(root([el]))
+    // unchanged (and reference identity of the string is irrelevant, value is)
+    assert.equal(el.textContent, "plain text")
+})

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -8,6 +8,13 @@ import assert from "node:assert/strict"
 // captured at load time (browser.js resolves it from globalThis). Both must be
 // in place *before* importing popup.js, so this file installs them on
 // globalThis and then dynamically imports the module under test.
+//
+// Contract: the mocks MUST be installed before the dynamic import() below —
+// keep it dynamic, do not turn it into a static import (those are hoisted and
+// would run before the mocks are set). The mocks are left on globalThis without
+// teardown; that is safe because `node --test` runs each test file in its own
+// process, so they cannot leak into other test files. Both assumptions break
+// under an in-process runner (e.g. --test-isolation=none).
 
 // a tiny stand-in for a DOM node: enough of the Element/DocumentFragment API
 // for render()/renderError() (setAttribute, textContent, appendChild,


### PR DESCRIPTION
The `localize` function was duplicated into popup and options ES modules. The function is now in a shared script and covered by tests.