### PR TITLE
refactor: extract duplicated local storage actions

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -60,6 +60,7 @@ On open, the popup:
 ├── background.js          # service worker: fetch PRs, match file, set badge
 ├── browser.js             # cross-browser WebExtension API shim (browser/chrome)
 ├── i18n.js                # shared localize() for the popup and options pages
+├── storage.js             # shared storage.local helpers (self-hosted instances)
 ├── forges.js              # per-forge API endpoint config
 ├── popup/
 │   ├── popup.html         # popup markup

--- a/background.js
+++ b/background.js
@@ -1,5 +1,6 @@
 import { browser } from './browser.js'
 import { forgeForHostname } from './forges.js'
+import { loadInstances } from './storage.js'
 
 //
 // Main
@@ -161,13 +162,6 @@ function render(prs, tabId) {
     // save results
     // keys: "tabId", "prs"
     browser.storage.local.set({ tabId, prs })
-}
-
-// load the user's configured self-hosted instances from storage
-// returns an array of { type, hostname } (empty when none configured)
-async function loadInstances() {
-    const stored = await browser.storage.local.get("selfHostedInstances")
-    return stored.selfHostedInstances || []
 }
 
 async function main(tab) {

--- a/options/options.js
+++ b/options/options.js
@@ -1,6 +1,7 @@
 import { browser } from "../browser.js"
 import { authForges, selfHostedTypes, selfHostedTokenKey } from "../forges.js"
 import { localize } from "../i18n.js"
+import { loadInstances, saveInstances } from "../storage.js"
 
 //
 // Functions
@@ -138,8 +139,7 @@ async function renderInstances() {
     const container = document.getElementById("instances")
     container.replaceChildren()
 
-    const stored = await browser.storage.local.get("selfHostedInstances")
-    const instances = stored.selfHostedInstances || []
+    const instances = await loadInstances()
     const typeLabels = Object.fromEntries(selfHostedTypes().map(t => [t.type, t.label]))
 
     for (const instance of instances) {
@@ -189,8 +189,7 @@ async function addInstance() {
     }
 
     try {
-        const stored = await browser.storage.local.get("selfHostedInstances")
-        const instances = stored.selfHostedInstances || []
+        const instances = await loadInstances()
 
         if (instances.some(i => i.hostname === hostname)) {
             showStatus("optionsInstanceExists", "instance-status")
@@ -206,7 +205,7 @@ async function addInstance() {
         }
 
         instances.push({ type, hostname })
-        await browser.storage.local.set({ selfHostedInstances: instances })
+        await saveInstances(instances)
         document.getElementById("instance-hostname").value = ""
         await renderInstances()
         await loadTokens()
@@ -220,10 +219,9 @@ async function addInstance() {
 // give back the host permission we no longer need
 async function removeInstance(hostname) {
     try {
-        const stored = await browser.storage.local.get("selfHostedInstances")
-        const instances = (stored.selfHostedInstances || []).filter(i => i.hostname !== hostname)
+        const instances = (await loadInstances()).filter(i => i.hostname !== hostname)
 
-        await browser.storage.local.set({ selfHostedInstances: instances })
+        await saveInstances(instances)
         await browser.storage.local.remove(selfHostedTokenKey(hostname))
         await browser.permissions.remove({ origins: [`*://${hostname}/*`] })
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,6 +1,7 @@
 import { browser } from "../browser.js"
 import { forgeForHostname } from "../forges.js"
 import { localize } from "../i18n.js"
+import { loadInstances } from "../storage.js"
 
 //
 // Functions
@@ -11,8 +12,7 @@ async function getUrlInfo(tab) {
 
     // pick the forge adapter (built-in or a configured self-hosted instance)
     // and parse the URL through it (null on a non-forge / non-file page)
-    const stored = await browser.storage.local.get("selfHostedInstances")
-    const forge = forgeForHostname(url.hostname, stored.selfHostedInstances || [])
+    const forge = forgeForHostname(url.hostname, await loadInstances())
     if (!forge) return null
     const info = forge.parseUrl(url)
     if (!info) return null

--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,16 @@
+import { browser } from "./browser.js"
+
+// storage.local key holding the user's configured self-hosted instances, each
+// an { type, hostname } object. Kept here so the key string lives in one place.
+const INSTANCES_KEY = "selfHostedInstances"
+
+// load the user's configured self-hosted instances ([] when none configured)
+export async function loadInstances() {
+    const stored = await browser.storage.local.get(INSTANCES_KEY)
+    return stored[INSTANCES_KEY] || []
+}
+
+// persist the self-hosted instances list
+export async function saveInstances(instances) {
+    await browser.storage.local.set({ [INSTANCES_KEY]: instances })
+}

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,44 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+// storage.js reads browser.storage.local through the browser shim, which
+// resolves from globalThis at import time; install a mock before importing.
+//
+// Contract: the mock MUST be installed before the dynamic import() below —
+// keep it dynamic, do not turn it into a static import (those are hoisted and
+// would run before the mock is set). The mock is left on globalThis without
+// teardown; that is safe because `node --test` runs each test file in its own
+// process, so it cannot leak into other test files. Both assumptions break
+// under an in-process runner (e.g. --test-isolation=none).
+
+// a stub storage.local recording the last set()/remove() and returning a
+// configurable backing object from get()
+let backing = {}
+const calls = { set: null }
+globalThis.browser = {
+    storage: {
+        local: {
+            get: async (key) => (key in backing ? { [key]: backing[key] } : {}),
+            set: async (obj) => { calls.set = obj },
+        },
+    },
+}
+const { loadInstances, saveInstances } = await import("../storage.js")
+
+test("loadInstances returns the stored instances", async () => {
+    backing = { selfHostedInstances: [{ type: "gitlab", hostname: "git.example.com" }] }
+    assert.deepEqual(await loadInstances(), [
+        { type: "gitlab", hostname: "git.example.com" },
+    ])
+})
+
+test("loadInstances defaults to an empty array when none are stored", async () => {
+    backing = {}
+    assert.deepEqual(await loadInstances(), [])
+})
+
+test("saveInstances writes under the selfHostedInstances key", async () => {
+    const instances = [{ type: "forgejo", hostname: "code.example.com" }]
+    await saveInstances(instances)
+    assert.deepEqual(calls.set, { selfHostedInstances: instances })
+})


### PR DESCRIPTION
The "selfHostedInstances" string was hardcoded at several places, and now is centralized to one shared place.