### PR TITLE
fix: convert the rate limit value into a number for comparison

### DIFF
--- a/background.js
+++ b/background.js
@@ -146,7 +146,7 @@ async function checkRateLimitFromPRs(forge, response) {
 
     // compare number of pull requests with rate limit
     console.log("Number of pull requests:", list.length)
-    if (remaining !== null && remaining <= list.length) {
+    if (remaining !== null && Number(remaining) <= list.length) {
         throw new Error("Rate limit reached!")
     }
     return list


### PR DESCRIPTION
In the `checkRateLimitFromPRs` function, the header value `remaining` comes as a string and is now wrapped in the `Number` function when compared to an integer.