### PR TITLE
fix: match forge hostnames exactly or by subdomain

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -36,7 +36,7 @@ It runs on both Firefox and Chrome from a single source tree:
 Runs on every tab update:
 
 1.   **Parse the URL**: extract `projectKey`, `repoSlug` and `filepath`
-2.   **Detect the forge** by hostname
+2.   **Detect the forge** by hostname (exact match or subdomain)
 3.   **Load the auth headers** for the forge from the stored token (if any)
 4.   **Promise chain**: list PRs, get files, keep PRs including the file
 5.   **Render**: set the toolbar badge text and stores `{ tabId, prs }` in
@@ -134,7 +134,7 @@ Here is the interface for each forge:
 | Member       | Purpose                                                            |
 | ------------ | ------------------------------------------------------------------ |
 | `label`      | human-readable forge name                                          |
-| `hostnames`  | array of hostnames matched against the page (one per family instance) |
+| `hostnames`  | array of hostnames matched against the page, exactly or as a subdomain (one per family instance) |
 | `base_url`   | API root URL the endpoint builders are hung off of                |
 | `parseUrl`   | `(URL) → { projectKey, repoSlug, filepath, origin }` or `null`     |
 | `listPRsUrl` | API endpoint listing the repo's open PRs                           |

--- a/forges.js
+++ b/forges.js
@@ -8,8 +8,9 @@
 //
 // Adapter interface:
 //   label       human-readable forge name, shown in the options page UI
-//   hostnames   array of substrings matched against the page hostname (for a
-//               family instance this is its single configured hostname)
+//   hostnames   array of hostnames matched against the page hostname, exactly
+//               or as a subdomain (for a family instance this is its single
+//               configured hostname)
 //   base_url    API root URL the endpoint builders below are hung off of
 //   parseUrl    (URL) -> { projectKey, repoSlug, filepath, origin } | null
 //   listPRsUrl  (info) -> API endpoint listing the repo's open pull requests
@@ -394,10 +395,14 @@ export function buildSelfHostedForge({ type, hostname }) {
 
 // pick a forge adapter for a page hostname, considering both the built-in
 // static forges and the user's configured self-hosted instances (null if none
-// matches). Static forges win; self-hosted instances are matched by exact
-// hostname to avoid one instance shadowing another.
+// matches). Static forges win; they match the exact hostname or a subdomain of
+// it — never a mere substring, so a hostile lookalike host (github.com.evil.example)
+// or an unrelated self-hosted forge (mygithub.company.com) stays unmatched.
+// Self-hosted instances are matched by exact hostname to avoid one instance
+// shadowing another.
 export function forgeForHostname(hostname, instances = []) {
-    const staticForge = staticForges.find(f => f.hostnames.some(h => hostname.includes(h)))
+    const staticForge = staticForges.find(f =>
+        f.hostnames.some(h => hostname === h || hostname.endsWith(`.${h}`)))
     if (staticForge) return staticForge
 
     const instance = instances.find(i => i.hostname === hostname)

--- a/tests/forges.test.js
+++ b/tests/forges.test.js
@@ -26,13 +26,21 @@ test("forgeForHostname matches gitlab.com", () => {
     assert.equal(forgeForHostname("gitlab.com"), gitlab)
 })
 
-test("forgeForHostname matches a subdomain containing the hostname", () => {
-    // hostnames are matched as substrings of the page hostname
+test("forgeForHostname matches a subdomain of a forge hostname", () => {
     assert.equal(forgeForHostname("www.github.com"), github)
 })
 
 test("forgeForHostname returns null for an unknown forge", () => {
     assert.equal(forgeForHostname("example.com"), null)
+})
+
+test("forgeForHostname does not match a forge hostname as a mere substring", () => {
+    // a hostile lookalike host must not be treated as the real forge (it would
+    // trigger API calls carrying the user's token for attacker-chosen paths)
+    assert.equal(forgeForHostname("github.com.evil.example"), null)
+    // an unrelated host merely containing the name is not the public forge
+    assert.equal(forgeForHostname("mygithub.company.com"), null)
+    assert.equal(forgeForHostname("evil-gitlab.com"), null)
 })
 
 //


### PR DESCRIPTION
Forge hostnames are matched exactly or by subdomain instead of by substring. So hostile hostnames like "github.com.evil.example" or "mygithub.company.com" are no longer matched, and no user's token can leak.