### PR TITLE
fix: allow pagination when listing PR and files

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -40,7 +40,9 @@ Runs on every tab update:
 1.   **Parse the URL**: extract `projectKey`, `repoSlug` and `filepath`
 2.   **Detect the forge** by hostname (exact match or subdomain)
 3.   **Load the auth headers** for the forge from the stored token (if any)
-4.   **Promise chain**: list PRs, get files, keep PRs including the file
+4.   **Promise chain**: list PRs, get files, keep PRs including the file —
+     following the forge's API pagination, so every page of PRs and files is
+     seen
 5.   **Render**: set the toolbar badge text and store the result under the
      tab's key in `browser.storage.session` — `{ prs }`, or `{ error }` when a
      request failed. Per-tab keys keep concurrent tabs from clobbering each
@@ -149,6 +151,7 @@ Here is the interface for each forge:
 | `filenames`  | filenames touched by a PR, from the files-endpoint response        |
 | `prNumber`   | identifier of a PR (used in URLs and displayed)                    |
 | `prWebUrl`   | web (non-API) URL of a PR, for the popup links                     |
+| `nextPageUrl` | `(response, data) → URL` of the next page of a paginated API response, or `null` on the last page |
 | `rateLimit`  | optional `{ url, header, remaining(data) }`; `null` if unsupported |
 | `tokenStorageKey` | optional `storage.local` key holding the user's token; omit for no auth |
 | `authHeader` | optional `(token) → headers` sent with API requests; omit for no auth |

--- a/background.js
+++ b/background.js
@@ -50,39 +50,45 @@ async function loadAuthHeaders(forge) {
     return authHeadersFor(forge, stored)
 }
 
-// fetch all pull requests
-// returns a promise with the list of pull requests
-async function listAllPRs(forge, urlInfo, requestHeaders) {
+// fetch every page of a paginated endpoint, following the forge's next-page
+// links; returns { items, response } where items concatenates normalize(data)
+// across the pages and response is the last HTTP response (for header checks)
+export async function fetchAllPages(forge, url, requestHeaders, normalize, errorLabel) {
+    const items = []
+    let response
+    while (url) {
+        response = await fetch(new Request(url, { headers: requestHeaders }))
+        const data = await response.json()
+
+        if (!response.ok) {
+            throw new Error(`${errorLabel}: [${response.status}] ${response.statusText}: ${data.message ?? data}`)
+        }
+
+        items.push(...normalize(data))
+        url = forge.nextPageUrl(response, data)
+    }
+    return { items, response }
+}
+
+// fetch all pull requests (across all pages)
+// returns a promise resolving to { items, response }
+function listAllPRs(forge, urlInfo, requestHeaders) {
     console.log("List all pull requests")
 
-    const request = new Request(forge.listPRsUrl(urlInfo), { headers: requestHeaders })
-
-    const response = await fetch(request)
-    //if (!response.ok) {
-    //    throw new Error(`Failed to list pull requests: [${response.status}] ${response.statusText}: ${data.message}`)
-    //}
-    return response
+    return fetchAllPages(
+        forge, forge.listPRsUrl(urlInfo), requestHeaders,
+        data => forge.pullRequests(data),
+        "Failed to list pull requests")
 }
 
-// fetch modified files of a pull request
-// returns a promise with the list of modified files for a pull request
-async function getModifiedFiles(forge, urlInfo, requestHeaders, pr) {
-    // fetch the API
-    const request = new Request(forge.filesUrl(urlInfo, pr), { headers: requestHeaders })
-
-    const response = await fetch(request)
-    const data = await response.json()
-
-    if (!response.ok) {
-        throw new Error(`Failed to list pull request modified files: [${response.status}] ${response.statusText}: ${data}`)
-    }
-    return data
-}
-
-// get filenames from a list of modified files
-// returns a list of filenames
-export function getFilenames(forge, files) {
-    return forge.filenames(files)
+// fetch the filenames modified by a pull request (across all pages)
+// returns a promise resolving to the list of filenames
+async function getModifiedFilenames(forge, urlInfo, requestHeaders, pr) {
+    const { items } = await fetchAllPages(
+        forge, forge.filesUrl(urlInfo, pr), requestHeaders,
+        data => forge.filenames(data),
+        "Failed to list pull request modified files")
+    return items
 }
 
 // returns the key if the item is in the array
@@ -98,8 +104,7 @@ export function addIfIncluded(array, item, key) {
 // per-PR file fetches run concurrently and the caller awaits them together
 export function getFilesPRs(forge, urlInfo, requestHeaders, prs) {
     return prs.map(async pr => {
-        const files = await getModifiedFiles(forge, urlInfo, requestHeaders, pr)
-        const filenames = getFilenames(forge, files)
+        const filenames = await getModifiedFilenames(forge, urlInfo, requestHeaders, pr)
         return addIfIncluded(filenames, urlInfo.filepath, forge.prNumber(pr))
     })
 }
@@ -128,28 +133,17 @@ async function checkRateLimit(forge, requestHeaders) {
     }
 }
 
-// check the rate limit comparing to PRs length
-async function checkRateLimitFromPRs(forge, response) {
+// check the rate limit comparing to PRs length (one files request each)
+function checkRateLimitFromPRs(forge, prs, response) {
     // get the rate limit header (forges without one skip the comparison)
     const remaining = forge.rateLimit ? response.headers.get(forge.rateLimit.header) : null
     console.log("Rate limit remaining (from header):", remaining)
 
-    const data = await response.json()
-
-    // check the "list" response
-    if (!response.ok) {
-        throw new Error(`Failed to list pull requests: [${response.status}] ${response.statusText}: ${data.message}`)
-    }
-
-    // normalize the list response to an array of PRs (forge-specific)
-    const list = forge.pullRequests(data)
-
     // compare number of pull requests with rate limit
-    console.log("Number of pull requests:", list.length)
-    if (remaining !== null && Number(remaining) <= list.length) {
+    console.log("Number of pull requests:", prs.length)
+    if (remaining !== null && Number(remaining) <= prs.length) {
         throw new Error("Rate limit reached!")
     }
-    return list
 }
 
 function render(prs, tabId) {
@@ -200,9 +194,9 @@ async function main(tab) {
         const requestHeaders = await loadAuthHeaders(forge)
         await checkRateLimit(forge, requestHeaders)
 
-        // list pull requests, then keep those that touch the file
-        const response = await listAllPRs(forge, urlInfo, requestHeaders)
-        const prs = await checkRateLimitFromPRs(forge, response)
+        // list pull requests (all pages), then keep those that touch the file
+        const { items: prs, response } = await listAllPRs(forge, urlInfo, requestHeaders)
+        checkRateLimitFromPRs(forge, prs, response)
         const values = await Promise.all(getFilesPRs(forge, urlInfo, requestHeaders, prs))
 
         // render (dropping the PRs that don't touch the file)

--- a/forges.js
+++ b/forges.js
@@ -19,12 +19,28 @@
 //   filenames   (filesResponse) -> array of filenames touched by a PR
 //   prNumber    (pr) -> identifier of a PR (used in URLs and displayed)
 //   prWebUrl    (info, prNumber) -> web (non-API) URL of a PR, for popup links
+//   nextPageUrl (response, data) -> URL of the next page of a paginated API
+//               response, or null on the last page
 //   rateLimit   optional { url, header, remaining(data) }; null if the forge
 //               exposes no rate-limit endpoint
 //   tokenStorageKey  optional storage.local key holding the user's API token;
 //                    omit if the forge supports no authentication
 //   authHeader  optional (token) -> headers object sent with API requests when
 //               a token is configured; omit if the forge supports no auth
+
+// parse an RFC 8288 `Link` response header and return the rel="next" URL
+// (null when there is no next page). Shared by the forges that paginate
+// through this standard header (GitHub, GitLab, Forgejo/Gitea).
+function nextFromLinkHeader(response) {
+    const link = response.headers.get("link")
+    if (!link) return null
+
+    for (const part of link.split(",")) {
+        const m = part.match(/<([^>]+)>\s*;.*rel="?next"?/)
+        if (m) return m[1]
+    }
+    return null
+}
 
 // API docs: https://docs.github.com/en/rest/pulls
 export const github = {
@@ -40,7 +56,8 @@ export const github = {
     },
 
     listPRsUrl(info) {
-        return `${this.base_url}/repos/${info.projectKey}/${info.repoSlug}/pulls`
+        // per_page raises the page size to the API maximum (default is 30)
+        return `${this.base_url}/repos/${info.projectKey}/${info.repoSlug}/pulls?per_page=100`
     },
 
     // the list endpoint already returns a JSON array of PRs
@@ -49,7 +66,7 @@ export const github = {
     },
 
     filesUrl(info, pr) {
-        return `${this.base_url}/repos/${info.projectKey}/${info.repoSlug}/pulls/${this.prNumber(pr)}/files`
+        return `${this.base_url}/repos/${info.projectKey}/${info.repoSlug}/pulls/${this.prNumber(pr)}/files?per_page=100`
     },
 
     filenames(files) {
@@ -62,6 +79,11 @@ export const github = {
 
     prWebUrl(info, prNumber) {
         return `${info.origin}/${info.projectKey}/${info.repoSlug}/pull/${prNumber}`
+    },
+
+    // GitHub paginates through the standard Link response header
+    nextPageUrl(response) {
+        return nextFromLinkHeader(response)
     },
 
     rateLimit: {
@@ -97,7 +119,8 @@ export const bitbucket = {
     },
 
     listPRsUrl(info) {
-        return `${this.base_url}/repositories/${info.projectKey}/${info.repoSlug}/pullrequests`
+        // pagelen raises the page size to the API maximum (default is 10)
+        return `${this.base_url}/repositories/${info.projectKey}/${info.repoSlug}/pullrequests?pagelen=50`
     },
 
     // the list endpoint wraps the PRs in a paginated envelope
@@ -120,6 +143,12 @@ export const bitbucket = {
 
     prWebUrl(info, prNumber) {
         return `${info.origin}/${info.projectKey}/${info.repoSlug}/pull-requests/${prNumber}`
+    },
+
+    // Bitbucket Cloud paginates in the body: the envelope carries the full
+    // URL of the next page (absent on the last one)
+    nextPageUrl(response, data) {
+        return data.next ?? null
     },
 
     // Bitbucket Cloud exposes no simple rate-limit endpoint.
@@ -170,7 +199,8 @@ const forgejoFamily = {
     },
 
     listPRsUrl(info) {
-        return `${this.base_url}/repos/${info.projectKey}/${info.repoSlug}/pulls`
+        // limit raises the page size to the default API maximum (50)
+        return `${this.base_url}/repos/${info.projectKey}/${info.repoSlug}/pulls?limit=50`
     },
 
     // the list endpoint returns a JSON array of PRs
@@ -179,7 +209,7 @@ const forgejoFamily = {
     },
 
     filesUrl(info, pr) {
-        return `${this.base_url}/repos/${info.projectKey}/${info.repoSlug}/pulls/${this.prNumber(pr)}/files`
+        return `${this.base_url}/repos/${info.projectKey}/${info.repoSlug}/pulls/${this.prNumber(pr)}/files?limit=50`
     },
 
     filenames(files) {
@@ -192,6 +222,11 @@ const forgejoFamily = {
 
     prWebUrl(info, prNumber) {
         return `${info.origin}/${info.projectKey}/${info.repoSlug}/pulls/${prNumber}`
+    },
+
+    // Forgejo/Gitea paginates through the standard Link response header
+    nextPageUrl(response) {
+        return nextFromLinkHeader(response)
     },
 
     // Forgejo/Gitea exposes no simple rate-limit endpoint.
@@ -234,8 +269,9 @@ const gitlabFamily = {
     },
 
     listPRsUrl(info) {
-        // /merge_requests defaults to every state, so filter to the open ones
-        return `${this.base_url}/projects/${this.projectId(info)}/merge_requests?state=opened`
+        // /merge_requests defaults to every state, so filter to the open ones;
+        // per_page raises the page size to the API maximum (default is 20)
+        return `${this.base_url}/projects/${this.projectId(info)}/merge_requests?state=opened&per_page=100`
     },
 
     // the list endpoint returns a JSON array of merge requests
@@ -244,7 +280,7 @@ const gitlabFamily = {
     },
 
     filesUrl(info, pr) {
-        return `${this.base_url}/projects/${this.projectId(info)}/merge_requests/${this.prNumber(pr)}/diffs`
+        return `${this.base_url}/projects/${this.projectId(info)}/merge_requests/${this.prNumber(pr)}/diffs?per_page=100`
     },
 
     // a diff entry keeps new_path == old_path for deletions, so new_path is safe
@@ -259,6 +295,11 @@ const gitlabFamily = {
 
     prWebUrl(info, prNumber) {
         return `${info.origin}/${info.projectPath}/-/merge_requests/${prNumber}`
+    },
+
+    // GitLab paginates through the standard Link response header
+    nextPageUrl(response) {
+        return nextFromLinkHeader(response)
     },
 
     // GitLab exposes rate-limit info only through response headers, not a
@@ -300,8 +341,9 @@ const bitbucketServerFamily = {
     },
 
     listPRsUrl(info) {
-        // the pull-requests endpoint defaults to OPEN, but be explicit
-        return `${this.base_url}/projects/${info.projectKey}/repos/${info.repoSlug}/pull-requests?state=OPEN`
+        // the pull-requests endpoint defaults to OPEN, but be explicit;
+        // limit raises the page size well above the default (25)
+        return `${this.base_url}/projects/${info.projectKey}/repos/${info.repoSlug}/pull-requests?state=OPEN&limit=100`
     },
 
     // the list endpoint wraps the PRs in a paginated envelope
@@ -310,7 +352,7 @@ const bitbucketServerFamily = {
     },
 
     filesUrl(info, pr) {
-        return `${this.base_url}/projects/${info.projectKey}/repos/${info.repoSlug}/pull-requests/${this.prNumber(pr)}/changes`
+        return `${this.base_url}/projects/${info.projectKey}/repos/${info.repoSlug}/pull-requests/${this.prNumber(pr)}/changes?limit=100`
     },
 
     // each change carries the file path as `path.toString`
@@ -328,6 +370,15 @@ const bitbucketServerFamily = {
             ? `users/${info.projectKey.slice(1)}/repos/${info.repoSlug}`
             : `projects/${info.projectKey}/repos/${info.repoSlug}`
         return `${info.origin}/${repoPath}/pull-requests/${prNumber}`
+    },
+
+    // Bitbucket Server paginates in the body: the envelope carries isLastPage
+    // and the start index of the next page, re-requested on the same URL
+    nextPageUrl(response, data) {
+        if (data.isLastPage || data.nextPageStart == null) return null
+        const url = new URL(response.url)
+        url.searchParams.set("start", data.nextPageStart)
+        return url.toString()
     },
 
     // Bitbucket Server exposes no simple rate-limit endpoint.

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,7 +1,7 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { addIfIncluded, getFilenames, authHeadersFor, getFilesPRs } from "../background.js"
+import { addIfIncluded, authHeadersFor, getFilesPRs, fetchAllPages } from "../background.js"
 import { github } from "../forges.js"
 
 //
@@ -26,18 +26,6 @@ test("addIfIncluded preserves a falsy key when the item is present", () => {
 })
 
 //
-// getFilenames (delegates to the forge adapter)
-//
-test("getFilenames delegates to the forge adapter", () => {
-    const files = [{ filename: "a.js" }, { filename: "dir/b.js" }]
-    assert.deepEqual(getFilenames(github, files), ["a.js", "dir/b.js"])
-})
-
-test("getFilenames returns an empty array for no files", () => {
-    assert.deepEqual(getFilenames(github, []), [])
-})
-
-//
 // authHeadersFor
 //
 test("authHeadersFor builds the auth header from a stored token", () => {
@@ -54,6 +42,70 @@ test("authHeadersFor returns no headers for a forge without authentication", () 
     // an adapter that declares no token key / header builder
     const forge = { hostnames: ["example.com"] }
     assert.deepEqual(authHeadersFor(forge, { githubToken: "ghp_secret" }), {})
+})
+
+//
+// fetchAllPages
+//
+test("fetchAllPages concatenates the pages following next links", async () => {
+    const realFetch = globalThis.fetch
+    const realRequest = globalThis.Request
+
+    // two pages chained by a next link, mapped by URL
+    const pages = {
+        "https://api.example.com/pulls": {
+            data: [{ number: 1 }, { number: 2 }],
+            next: "https://api.example.com/pulls?page=2",
+        },
+        "https://api.example.com/pulls?page=2": {
+            data: [{ number: 3 }],
+            next: null,
+        },
+    }
+    globalThis.Request = class { constructor(url) { this.url = url } }
+    globalThis.fetch = async request => ({
+        ok: true,
+        url: request.url,
+        headers: { get: () => null },
+        json: async () => pages[request.url].data,
+    })
+    // a minimal forge whose nextPageUrl walks the chain above
+    const forge = { nextPageUrl: (response) => pages[response.url].next }
+
+    try {
+        const { items, response } = await fetchAllPages(
+            forge, "https://api.example.com/pulls", {}, data => data, "unused")
+        assert.deepEqual(items, [{ number: 1 }, { number: 2 }, { number: 3 }])
+        // the last response is returned, for rate-limit header checks
+        assert.equal(response.url, "https://api.example.com/pulls?page=2")
+    } finally {
+        globalThis.fetch = realFetch
+        globalThis.Request = realRequest
+    }
+})
+
+test("fetchAllPages throws on a non-ok response", async () => {
+    const realFetch = globalThis.fetch
+    const realRequest = globalThis.Request
+
+    globalThis.Request = class { constructor(url) { this.url = url } }
+    globalThis.fetch = async () => ({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        headers: { get: () => null },
+        json: async () => ({ message: "rate limited" }),
+    })
+
+    try {
+        await assert.rejects(
+            fetchAllPages(github, "https://api.example.com/pulls", {}, data => data,
+                "Failed to list pull requests"),
+            /Failed to list pull requests: \[403\] Forbidden: rate limited/)
+    } finally {
+        globalThis.fetch = realFetch
+        globalThis.Request = realRequest
+    }
 })
 
 //
@@ -75,6 +127,7 @@ test("getFilesPRs uses its own arguments under interleaved concurrent calls", as
     globalThis.fetch = () => new Promise(resolve => {
         resolvers.push(() => resolve({
             ok: true,
+            headers: { get: () => null },  // single page: no Link header
             json: async () => [{ filename: "a.js" }, { filename: "b.js" }],
         }))
     })

--- a/tests/forges.test.js
+++ b/tests/forges.test.js
@@ -75,14 +75,14 @@ test("github.listPRsUrl builds the pulls endpoint", () => {
     const info = { projectKey: "Linkid", repoSlug: "git-pr-reverse" }
     assert.equal(
         github.listPRsUrl(info),
-        "https://api.github.com/repos/Linkid/git-pr-reverse/pulls")
+        "https://api.github.com/repos/Linkid/git-pr-reverse/pulls?per_page=100")
 })
 
 test("github.filesUrl builds the files endpoint for a PR", () => {
     const info = { projectKey: "Linkid", repoSlug: "git-pr-reverse" }
     assert.equal(
         github.filesUrl(info, { number: 42 }),
-        "https://api.github.com/repos/Linkid/git-pr-reverse/pulls/42/files")
+        "https://api.github.com/repos/Linkid/git-pr-reverse/pulls/42/files?per_page=100")
 })
 
 test("github.prWebUrl builds the web URL of a PR", () => {
@@ -160,7 +160,7 @@ test("bitbucket.listPRsUrl builds the pullrequests endpoint", () => {
     const info = { projectKey: "acme", repoSlug: "widget" }
     assert.equal(
         bitbucket.listPRsUrl(info),
-        "https://api.bitbucket.org/2.0/repositories/acme/widget/pullrequests")
+        "https://api.bitbucket.org/2.0/repositories/acme/widget/pullrequests?pagelen=50")
 })
 
 test("bitbucket.filesUrl builds the diffstat endpoint for a PR", () => {
@@ -235,14 +235,14 @@ test("codeberg.listPRsUrl builds the pulls endpoint", () => {
     const info = { projectKey: "acme", repoSlug: "widget" }
     assert.equal(
         codeberg.listPRsUrl(info),
-        "https://codeberg.org/api/v1/repos/acme/widget/pulls")
+        "https://codeberg.org/api/v1/repos/acme/widget/pulls?limit=50")
 })
 
 test("codeberg.filesUrl builds the files endpoint for a PR", () => {
     const info = { projectKey: "acme", repoSlug: "widget" }
     assert.equal(
         codeberg.filesUrl(info, { number: 42 }),
-        "https://codeberg.org/api/v1/repos/acme/widget/pulls/42/files")
+        "https://codeberg.org/api/v1/repos/acme/widget/pulls/42/files?limit=50")
 })
 
 test("codeberg.prWebUrl builds the web URL of a PR", () => {
@@ -303,14 +303,14 @@ test("gitlab.listPRsUrl builds the merge_requests endpoint with the encoded path
     const info = { projectPath: "group/subgroup/widget" }
     assert.equal(
         gitlab.listPRsUrl(info),
-        "https://gitlab.com/api/v4/projects/group%2Fsubgroup%2Fwidget/merge_requests?state=opened")
+        "https://gitlab.com/api/v4/projects/group%2Fsubgroup%2Fwidget/merge_requests?state=opened&per_page=100")
 })
 
 test("gitlab.filesUrl builds the diffs endpoint for a merge request", () => {
     const info = { projectPath: "acme/widget" }
     assert.equal(
         gitlab.filesUrl(info, { iid: 42 }),
-        "https://gitlab.com/api/v4/projects/acme%2Fwidget/merge_requests/42/diffs")
+        "https://gitlab.com/api/v4/projects/acme%2Fwidget/merge_requests/42/diffs?per_page=100")
 })
 
 test("gitlab.prWebUrl builds the web URL of a merge request", () => {
@@ -345,6 +345,46 @@ test("gitlab.authHeader builds a PRIVATE-TOKEN header", () => {
 })
 
 //
+// pagination
+//
+test("github.nextPageUrl follows the Link header rel=next", () => {
+    const link = '<https://api.github.com/repos/a/b/pulls?page=2>; rel="next", ' +
+        '<https://api.github.com/repos/a/b/pulls?page=5>; rel="last"'
+    const response = { headers: { get: () => link } }
+    assert.equal(github.nextPageUrl(response, []), "https://api.github.com/repos/a/b/pulls?page=2")
+})
+
+test("github.nextPageUrl returns null on the last page", () => {
+    // no Link header at all
+    assert.equal(github.nextPageUrl({ headers: { get: () => null } }, []), null)
+    // a Link header without a rel="next" entry
+    const link = '<https://api.github.com/repos/a/b/pulls?page=1>; rel="first"'
+    assert.equal(github.nextPageUrl({ headers: { get: () => link } }, []), null)
+})
+
+test("gitlab and codeberg paginate through the Link header too", () => {
+    const response = { headers: { get: () => '<https://example.com/api?page=2>; rel="next"' } }
+    assert.equal(gitlab.nextPageUrl(response, []), "https://example.com/api?page=2")
+    assert.equal(codeberg.nextPageUrl(response, []), "https://example.com/api?page=2")
+})
+
+test("bitbucket.nextPageUrl reads the next URL off the envelope", () => {
+    const next = "https://api.bitbucket.org/2.0/repositories/acme/widget/pullrequests?page=2"
+    assert.equal(bitbucket.nextPageUrl({}, { values: [], next }), next)
+    // the last page carries no `next` field
+    assert.equal(bitbucket.nextPageUrl({}, { values: [] }), null)
+})
+
+test("bitbucket-server nextPageUrl re-requests the same URL at nextPageStart", () => {
+    const forge = buildSelfHostedForge({ type: "bitbucket-server", hostname: "bitbucket.example.com" })
+    const response = { url: "https://bitbucket.example.com/rest/api/latest/projects/PRJ/repos/widget/pull-requests?state=OPEN&limit=100" }
+    assert.equal(
+        forge.nextPageUrl(response, { isLastPage: false, nextPageStart: 100 }),
+        "https://bitbucket.example.com/rest/api/latest/projects/PRJ/repos/widget/pull-requests?state=OPEN&limit=100&start=100")
+    assert.equal(forge.nextPageUrl(response, { isLastPage: true }), null)
+})
+
+//
 // self-hosted forges
 //
 test("selfHostedTypes lists the supported software with labels", () => {
@@ -376,7 +416,7 @@ test("buildSelfHostedForge builds a GitLab instance adapter reusing the gitlab l
     const info = { projectPath: "group/widget", origin: "https://gitlab.example.com" }
     assert.equal(
         forge.listPRsUrl(info),
-        "https://gitlab.example.com/api/v4/projects/group%2Fwidget/merge_requests?state=opened")
+        "https://gitlab.example.com/api/v4/projects/group%2Fwidget/merge_requests?state=opened&per_page=100")
     assert.equal(forge.prNumber({ iid: 7 }), 7)
     assert.deepEqual(forge.authHeader("gl_secret"), { "PRIVATE-TOKEN": "gl_secret" })
 })
@@ -388,7 +428,7 @@ test("buildSelfHostedForge builds a Forgejo instance adapter reusing the codeber
     const info = { projectKey: "acme", repoSlug: "widget" }
     assert.equal(
         forge.filesUrl(info, { number: 42 }),
-        "https://git.example.com/api/v1/repos/acme/widget/pulls/42/files")
+        "https://git.example.com/api/v1/repos/acme/widget/pulls/42/files?limit=50")
     assert.deepEqual(forge.authHeader("cb_secret"), { Authorization: "token cb_secret" })
 })
 
@@ -401,10 +441,10 @@ test("buildSelfHostedForge builds a Bitbucket Server instance adapter", () => {
     const info = { projectKey: "PRJ", repoSlug: "widget", origin: "https://bitbucket.example.com" }
     assert.equal(
         forge.listPRsUrl(info),
-        "https://bitbucket.example.com/rest/api/latest/projects/PRJ/repos/widget/pull-requests?state=OPEN")
+        "https://bitbucket.example.com/rest/api/latest/projects/PRJ/repos/widget/pull-requests?state=OPEN&limit=100")
     assert.equal(
         forge.filesUrl(info, { id: 7 }),
-        "https://bitbucket.example.com/rest/api/latest/projects/PRJ/repos/widget/pull-requests/7/changes")
+        "https://bitbucket.example.com/rest/api/latest/projects/PRJ/repos/widget/pull-requests/7/changes?limit=100")
     assert.equal(
         forge.prWebUrl(info, 7),
         "https://bitbucket.example.com/projects/PRJ/repos/widget/pull-requests/7")
@@ -439,7 +479,7 @@ test("bitbucket-server addresses a personal repo as ~userSlug in the API but /us
     const info = { projectKey: "~jdoe", repoSlug: "widget", origin: "https://bitbucket.example.com" }
     assert.equal(
         forge.listPRsUrl(info),
-        "https://bitbucket.example.com/rest/api/latest/projects/~jdoe/repos/widget/pull-requests?state=OPEN")
+        "https://bitbucket.example.com/rest/api/latest/projects/~jdoe/repos/widget/pull-requests?state=OPEN&limit=100")
     assert.equal(
         forge.prWebUrl(info, 7),
         "https://bitbucket.example.com/users/jdoe/repos/widget/pull-requests/7")


### PR DESCRIPTION
A new member of forge adapter is used to add pagination: `nextPageUrl`. This new member is applied to existing adapters:
- GitHub / GitLab / Forgejo-Gitea: read `Link` header
- Bitbucket (both): read the body envelope.

Then, repos with many open PRs, or PRs touching many files, are no longer silently truncated.