### PR TITLE
fix: enable toolbar action after URL parsing

### DIFF
--- a/background.js
+++ b/background.js
@@ -176,14 +176,15 @@ async function main(tab) {
         return
     }
 
-    browser.action.enable(tab.id)
-
-    // get project info from the URL (forge-specific parsing)
+    // get project info from the URL (forge-specific parsing); enable the
+    // action only once the URL is known good, so the badge never flickers
+    // on non-file pages (disable covers a file -> non-file navigation)
     const urlInfo = forge.parseUrl(url)
     if (urlInfo == null) {
         browser.action.disable(tab.id)
         return
     }
+    browser.action.enable(tab.id)
 
     // drop the result of the tab's previous page: the popup shows its loading
     // state until this page's result lands


### PR DESCRIPTION
The action is enabled only after `parseUrl` returns a good `urlInfo`, removing the badge flicker on non-file forge pages.