### PR TITLE
fix: cap the concurrent per-PR file fetches at 10

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -37,12 +37,13 @@ It runs on both Firefox and Chrome from a single source tree:
 
 Runs on every tab update:
 
-1.   **Parse the URL**: extract `projectKey`, `repoSlug` and `filepath`
-2.   **Detect the forge** by hostname (exact match or subdomain)
+1.   **Detect the forge** by hostname (exact match or subdomain)
+2.   **Parse the URL**: extract `projectKey`, `repoSlug` and `filepath`
 3.   **Load the auth headers** for the forge from the stored token (if any)
 4.   **Promise chain**: list PRs, get files, keep PRs including the file —
      following the forge's API pagination, so every page of PRs and files is
-     seen
+     seen. The per-PR file fetches run concurrently, capped at 10 in flight
+     so a repo with many open PRs doesn't trip forge abuse protections
 5.   **Render**: set the toolbar badge text and store the result under the
      tab's key in `browser.storage.session` — `{ prs }`, or `{ error }` when a
      request failed. Per-tab keys keep concurrent tabs from clobbering each

--- a/background.js
+++ b/background.js
@@ -99,11 +99,35 @@ export function addIfIncluded(array, item, key) {
     return null
 }
 
+// cap on the number of per-PR file fetches in flight at once: firing one
+// request per PR on a repo with 100+ open PRs trips forge abuse protections
+// (e.g. GitHub's secondary rate limits, which watch concurrency, not quota)
+const MAX_CONCURRENT_FETCHES = 10
+
+// run task(item) over the items with at most `limit` tasks in flight; resolves
+// to the results in item order. A worker pool: each worker pulls the next
+// unclaimed index until the items run out, so a slot frees as soon as its task
+// settles. Rejects on the first task error, like Promise.all.
+export async function mapWithConcurrency(items, limit, task) {
+    const results = new Array(items.length)
+    let next = 0
+    const workers = Array.from({ length: Math.min(limit, items.length) },
+        async () => {
+            while (next < items.length) {
+                const index = next++
+                results[index] = await task(items[index])
+            }
+        })
+    await Promise.all(workers)
+    return results
+}
+
 // get all pull requests containing a file
-// returns a list of promises, each resolving to a PR number (or null); the
-// per-PR file fetches run concurrently and the caller awaits them together
+// returns a promise resolving to a list of PR numbers (null for the PRs that
+// don't touch the file); the per-PR file fetches run concurrently, capped at
+// MAX_CONCURRENT_FETCHES in flight
 export function getFilesPRs(forge, urlInfo, requestHeaders, prs) {
-    return prs.map(async pr => {
+    return mapWithConcurrency(prs, MAX_CONCURRENT_FETCHES, async pr => {
         const filenames = await getModifiedFilenames(forge, urlInfo, requestHeaders, pr)
         return addIfIncluded(filenames, urlInfo.filepath, forge.prNumber(pr))
     })
@@ -198,7 +222,7 @@ async function main(tab) {
         // list pull requests (all pages), then keep those that touch the file
         const { items: prs, response } = await listAllPRs(forge, urlInfo, requestHeaders)
         checkRateLimitFromPRs(forge, prs, response)
-        const values = await Promise.all(getFilesPRs(forge, urlInfo, requestHeaders, prs))
+        const values = await getFilesPRs(forge, urlInfo, requestHeaders, prs)
 
         // render (dropping the PRs that don't touch the file)
         render(values.filter(x => x), tab.id)

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,7 +1,7 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { addIfIncluded, authHeadersFor, getFilesPRs, fetchAllPages } from "../background.js"
+import { addIfIncluded, authHeadersFor, getFilesPRs, fetchAllPages, mapWithConcurrency } from "../background.js"
 import { github } from "../forges.js"
 
 //
@@ -109,6 +109,54 @@ test("fetchAllPages throws on a non-ok response", async () => {
 })
 
 //
+// mapWithConcurrency
+//
+test("mapWithConcurrency caps the tasks in flight and keeps item order", async () => {
+    // each task parks its resolver so the test controls when a slot frees
+    const resolvers = []
+    let started = 0
+    const task = item => new Promise(resolve => {
+        started++
+        resolvers.push(() => resolve(item * 10))
+    })
+
+    const result = mapWithConcurrency([0, 1, 2, 3, 4], 2, task)
+
+    // only `limit` tasks start; the rest wait for a slot
+    assert.equal(started, 2)
+
+    // finishing a task (out of order) frees its slot for the next item
+    resolvers[1]()
+    await Promise.resolve()
+    assert.equal(started, 3)
+    resolvers[0]()
+    await Promise.resolve()
+    assert.equal(started, 4)
+    resolvers[3]()
+    await Promise.resolve()
+    assert.equal(started, 5)
+    resolvers[2]()
+    resolvers[4]()
+
+    // results follow the item order, not the completion order
+    assert.deepEqual(await result, [0, 10, 20, 30, 40])
+})
+
+test("mapWithConcurrency handles more slots than items", async () => {
+    assert.deepEqual(await mapWithConcurrency([1, 2], 10, async x => x + 1), [2, 3])
+})
+
+test("mapWithConcurrency resolves to an empty array for no items", async () => {
+    assert.deepEqual(await mapWithConcurrency([], 10, async x => x), [])
+})
+
+test("mapWithConcurrency rejects when a task throws", async () => {
+    await assert.rejects(
+        mapWithConcurrency([1, 2], 2, async x => { throw new Error(`task ${x}`) }),
+        /task 1/)
+})
+
+//
 // getFilesPRs — regression guard for the per-tab state race
 //
 // getFilesPRs must derive its result solely from the forge/urlInfo passed to
@@ -134,8 +182,8 @@ test("getFilesPRs uses its own arguments under interleaved concurrent calls", as
 
     try {
         // both calls start and reach their `await fetch` before either resolves
-        const callA = Promise.all(getFilesPRs(github, { filepath: "a.js" }, {}, [{ number: 1 }]))
-        const callB = Promise.all(getFilesPRs(github, { filepath: "missing.js" }, {}, [{ number: 2 }]))
+        const callA = getFilesPRs(github, { filepath: "a.js" }, {}, [{ number: 1 }])
+        const callB = getFilesPRs(github, { filepath: "missing.js" }, {}, [{ number: 2 }])
 
         // release out of order (B before A) to force interleaving
         resolvers[1]()


### PR DESCRIPTION
The new `mapWithConcurrency` function helper create a worker pool where each worker pulls  the next unclaimed index until the items run out. A slot frees as soon as its task settles, results come back in item order, and it rejects on the first task error (same semantics as Promise.all before).
The `getFilesPRs` function now runs its per-PR fetches through that pool with `MAX_CONCURRENT_FETCHES = 10`, and returns a promise of the resultsarray directly instead of a list of promises. Then repos with many open PRs no longer trip forge abuse protections.