### PR TITLE
perf: drop the rate limit pre-check request

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -153,7 +153,7 @@ Here is the interface for each forge:
 | `prNumber`   | identifier of a PR (used in URLs and displayed)                    |
 | `prWebUrl`   | web (non-API) URL of a PR, for the popup links                     |
 | `nextPageUrl` | `(response, data) → URL` of the next page of a paginated API response, or `null` on the last page |
-| `rateLimit`  | optional `{ url, header, remaining(data) }`; `null` if unsupported |
+| `rateLimit`  | optional `{ header }`: response header carrying the remaining request quota; `null` if unsupported |
 | `tokenStorageKey` | optional `storage.local` key holding the user's token; omit for no auth |
 | `authHeader` | optional `(token) → headers` sent with API requests; omit for no auth |
 

--- a/background.js
+++ b/background.js
@@ -133,31 +133,9 @@ export function getFilesPRs(forge, urlInfo, requestHeaders, prs) {
     })
 }
 
-// check the rate limit
-async function checkRateLimit(forge, requestHeaders) {
-    // forges without a rate-limit endpoint skip this check
-    if (!forge.rateLimit) {
-        return
-    }
-
-    console.log("Check the rate limit")
-
-    // fetch the rate limit endpoint
-    const response = await fetch(forge.rateLimit.url, { headers: requestHeaders })
-    const data = await response.json()
-
-    if (!response.ok) {
-        throw new Error(`Failed to get rate limits: [${response.status}] ${response.statusText}: ${data.message}`)
-    }
-
-    const remaining = forge.rateLimit.remaining(data)
-    console.log("Rate limit remaining:", remaining)
-    if (remaining == 0) {
-        throw new Error("Rate limit reached!")
-    }
-}
-
-// check the rate limit comparing to PRs length (one files request each)
+// check the rate limit comparing to PRs length (one files request each); the
+// header rides on the list response, so the check costs no extra request (an
+// already-exhausted quota fails the list request itself)
 function checkRateLimitFromPRs(forge, prs, response) {
     // get the rate limit header (forges without one skip the comparison)
     const remaining = forge.rateLimit ? response.headers.get(forge.rateLimit.header) : null
@@ -215,9 +193,8 @@ async function main(tab) {
     await clearTabResult(tab.id)
 
     try {
-        // load the stored API token, then check the forge rate limit
+        // load the stored API token
         const requestHeaders = await loadAuthHeaders(forge)
-        await checkRateLimit(forge, requestHeaders)
 
         // list pull requests (all pages), then keep those that touch the file
         const { items: prs, response } = await listAllPRs(forge, urlInfo, requestHeaders)

--- a/forges.js
+++ b/forges.js
@@ -21,8 +21,8 @@
 //   prWebUrl    (info, prNumber) -> web (non-API) URL of a PR, for popup links
 //   nextPageUrl (response, data) -> URL of the next page of a paginated API
 //               response, or null on the last page
-//   rateLimit   optional { url, header, remaining(data) }; null if the forge
-//               exposes no rate-limit endpoint
+//   rateLimit   optional { header }: the response header carrying the
+//               remaining request quota; null if the forge exposes none
 //   tokenStorageKey  optional storage.local key holding the user's API token;
 //                    omit if the forge supports no authentication
 //   authHeader  optional (token) -> headers object sent with API requests when
@@ -87,9 +87,7 @@ export const github = {
     },
 
     rateLimit: {
-        url: "https://api.github.com/rate_limit",
         header: "x-ratelimit-remaining",
-        remaining: (data) => data.resources.core.remaining,
     },
 
     // GitHub accepts classic and fine-grained personal access tokens as a

--- a/tests/forges.test.js
+++ b/tests/forges.test.js
@@ -111,13 +111,7 @@ test("github.filenames returns an empty array for no files", () => {
 //
 // rate limit
 //
-test("github.rateLimit.remaining reads the core remaining count", () => {
-    const data = { resources: { core: { remaining: 58 } } }
-    assert.equal(github.rateLimit.remaining(data), 58)
-})
-
-test("github.rateLimit exposes the endpoint and header", () => {
-    assert.equal(github.rateLimit.url, "https://api.github.com/rate_limit")
+test("github.rateLimit exposes the remaining-quota header", () => {
     assert.equal(github.rateLimit.header, "x-ratelimit-remaining")
 })
 


### PR DESCRIPTION
The header-based check is already done on the list response. The forge adapter is upgraded to only keep the header name for rate limit check