### PR TITLE
refactor(background): inline addIfIncluded helper

### DIFF
--- a/background.js
+++ b/background.js
@@ -91,14 +91,6 @@ async function getModifiedFilenames(forge, urlInfo, requestHeaders, pr) {
     return items
 }
 
-// returns the key if the item is in the array
-export function addIfIncluded(array, item, key) {
-    if (array.includes(item)) {
-        return key
-    }
-    return null
-}
-
 // cap on the number of per-PR file fetches in flight at once: firing one
 // request per PR on a repo with 100+ open PRs trips forge abuse protections
 // (e.g. GitHub's secondary rate limits, which watch concurrency, not quota)
@@ -129,7 +121,7 @@ export async function mapWithConcurrency(items, limit, task) {
 export function getFilesPRs(forge, urlInfo, requestHeaders, prs) {
     return mapWithConcurrency(prs, MAX_CONCURRENT_FETCHES, async pr => {
         const filenames = await getModifiedFilenames(forge, urlInfo, requestHeaders, pr)
-        return addIfIncluded(filenames, urlInfo.filepath, forge.prNumber(pr))
+        return filenames.includes(urlInfo.filepath) ? forge.prNumber(pr) : null
     })
 }
 

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,29 +1,8 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { addIfIncluded, authHeadersFor, getFilesPRs, fetchAllPages, mapWithConcurrency } from "../background.js"
+import { authHeadersFor, getFilesPRs, fetchAllPages, mapWithConcurrency } from "../background.js"
 import { github } from "../forges.js"
-
-//
-// addIfIncluded
-//
-test("addIfIncluded returns the key when the item is in the array", () => {
-    assert.equal(addIfIncluded(["a.js", "b.js"], "a.js", 42), 42)
-})
-
-test("addIfIncluded returns null when the item is absent", () => {
-    assert.equal(addIfIncluded(["a.js", "b.js"], "c.js", 42), null)
-})
-
-test("addIfIncluded returns null for an empty array", () => {
-    assert.equal(addIfIncluded([], "a.js", 42), null)
-})
-
-test("addIfIncluded preserves a falsy key when the item is present", () => {
-    // a PR number of 0 is unrealistic, but the helper must not confuse a
-    // present-but-falsy key with the absent case
-    assert.equal(addIfIncluded(["a.js"], "a.js", 0), 0)
-})
 
 //
 // authHeadersFor


### PR DESCRIPTION
The `addIfIncluded` function helper is replaced by the code directly into `getFilesPRs` as it is trivial and used only there.