### PR TITLE
fix(options): request the host permission before reading storage

### DIFF
--- a/options/options.js
+++ b/options/options.js
@@ -233,19 +233,22 @@ async function addInstance() {
     }
 
     try {
-        const instances = await loadInstances()
-
-        if (instances.some(i => i.hostname === hostname)) {
-            showStatus("optionsInstanceExists", "instance-status")
-            return
-        }
-
         // the extension may only call the queried API (the review server for
-        // a Gerrit instance) once the user grants access to its origin
+        // a Gerrit instance) once the user grants access to its origin.
+        // permissions.request() must run before any other await, or it loses
+        // the click's user-activation context and the browser rejects it; an
+        // already-granted host (the duplicate case) resolves without a prompt.
         const granted = await browser.permissions.request(
             { origins: [`*://${permissionHostname(instance)}/*`] })
         if (!granted) {
             showStatus("optionsPermissionDenied", "instance-status")
+            return
+        }
+
+        const instances = await loadInstances()
+
+        if (instances.some(i => i.hostname === hostname)) {
+            showStatus("optionsInstanceExists", "instance-status")
             return
         }
 


### PR DESCRIPTION
For self-hosted instances, the permission request was asked too early: the handler called `loadInstances` first, then read `storage.local` which consumed the activation, so the request was no longer "inside" the click.
A reordering has been done to keep the grant.

Ref #33